### PR TITLE
New GPIO interface requires unique bank label.

### DIFF
--- a/gpio-nct5104d.c
+++ b/gpio-nct5104d.c
@@ -124,14 +124,14 @@ static int nct5104d_gpio_direction_out(struct gpio_chip *chip,
 				     unsigned offset, int value);
 static void nct5104d_gpio_set(struct gpio_chip *chip, unsigned offset, int value);
 
-#define NCT5104D_GPIO_BANK(_base, _ngpio, _regbase)			\
+#define NCT5104D_GPIO_BANK(_bank, _base, _ngpio, _regbase)		\
 	{								\
 		.chip = {						\
-			.label            = DRVNAME,			\
+			.label            = DRVNAME "-bank" _bank,	\
 			.owner            = THIS_MODULE,		\
 			.direction_input  = nct5104d_gpio_direction_in,	\
 			.get              = nct5104d_gpio_get,		\
-			.direction_output = nct5104d_gpio_direction_out,	\
+			.direction_output = nct5104d_gpio_direction_out,\
 			.set              = nct5104d_gpio_set,		\
 			.base             = _base,			\
 			.ngpio            = _ngpio,			\
@@ -144,8 +144,8 @@ static void nct5104d_gpio_set(struct gpio_chip *chip, unsigned offset, int value
 #define gpio_data(base) (base + 1)
 
 static struct nct5104d_gpio_bank nct5104d_gpio_bank[] = {
-	NCT5104D_GPIO_BANK(0 , 8, 0xE0),
-	NCT5104D_GPIO_BANK(10, 8, 0xE4)
+	NCT5104D_GPIO_BANK("0", 0 , 8, 0xE0),
+	NCT5104D_GPIO_BANK("1", 10, 8, 0xE4)
 };
 
 static int nct5104d_gpio_direction_in(struct gpio_chip *chip, unsigned offset)


### PR DESCRIPTION
The two banks are registered as separate chips (`gpiochip0`, `gpiochip10`) but with an identical `chip->label`. Since the unique GPIO integer is now replaced by a `gpio_desc` (`chip->label`, `chip->hwnum`), `chip->label` has to be unique since `chip->hwnum` is not. If `chip->label` is not unique, always the first match (bank `gpiochip0`) is selected by the new descriptor-based GPIO interface, see line 3668 in [gpiolib.c](https://elixir.bootlin.com/linux/v4.19.16/source/drivers/gpio/gpiolib.c#L3668). This fix is backward-compatible.

The two banks:
```
/sys/class/gpio/gpiochip0 (base 0)
/sys/class/gpio/gpiochip10 (base 10)
```

Exporting works as expected as this is implemented by the legacy integer-based interface:
```
echo 0 > /sys/class/gpio/export
echo 10 > /sys/class/gpio/export
```

**Without Fix**

An implementation using the new descriptor-based interface would select the **wrong bank**:
```c
// `drivers/i2c/busses/i2c-gpio-custom.c`:

gpio = 0;
bank = gpio_to_chip(gpio);
gpiod_lookup_table->table[0].chip_label =bank->label; // "gpio-nct5104d"
gpiod_lookup_table->table[0].chip_hwnum = gpio - bank->base; // 0 -> 1st GPIO of bank0
gpiod_lookup_table->table[0].con_id = "sda";

gpio = 11;
bank = gpio_to_chip(gpio);
gpiod_lookup_table->table[1].chip_label = bank->label; // "gpio-nct5104d"
gpiod_lookup_table->table[1].chip_hwnum = gpio - bank->base; // 0 -> 2nd GPIO of bank1
gpiod_lookup_table->table[1].con_id = "scl";

// `drivers/i2c/busses/i2c-gpio.c`:

priv->sda = i2c_gpio_get_desc(dev, "sda", 0, gflags);
// priv->sda->chip->label = "gpio-nct5104d" // First match!
// priv->sda->chip->base = 0 -> Here ok!
priv->scl = i2c_gpio_get_desc(dev, "scl", 1, gflags);
// priv->scl->chip->label = "gpio-nct5104d" // Also first match!
// priv->scl->chip->base = 0 -> Here **not** ok, it should be 10
```
Selected GPIOs:
```
/sys/class/gpio/gpio0
/sys/class/gpio/gpio1 // Wrong bank, it should be `gpio11`!
```

**With Fix**

Fixed by making bank label unique: 
```c
// `drivers/i2c/busses/i2c-gpio-custom.c`:

gpio = 0;
bank = gpio_to_chip(gpio);
gpiod_lookup_table->table[0].chip_label =bank->label; // "gpio-nct5104d-bank0"
gpiod_lookup_table->table[0].chip_hwnum = gpio - bank->base; // 0 -> 1st GPIO of bank0
gpiod_lookup_table->table[0].con_id = "sda";

gpio = 11;
bank = gpio_to_chip(gpio);
gpiod_lookup_table->table[1].chip_label = bank->label; // "gpio-nct5104d-bank1"
gpiod_lookup_table->table[1].chip_hwnum = gpio - bank->base; // 0 -> 2nd GPIO of bank1
gpiod_lookup_table->table[1].con_id = "scl";

// `drivers/i2c/busses/i2c-gpio.c`:

priv->sda = i2c_gpio_get_desc(dev, "sda", 0, gflags);
// priv->sda->chip->label = "gpio-nct5104d-bank0" // Unique match!
// priv->sda->chip->base = 0 -> Ok!
priv->scl = i2c_gpio_get_desc(dev, "scl", 1, gflags);
// priv->scl->chip->label = "gpio-nct5104d-bank1" // Unique match!
// priv->scl->chip->base = 10 -> Ok!
```
Selected GPIOs:
```
/sys/class/gpio/gpio0
/sys/class/gpio/gpio11 // Correct bank!
```