### PR TITLE
Fix build failure for kernel >= 5.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
-#
 obj-m := gpio-nct5104d.o
 KDIR ?= /lib/modules/$(shell uname -r)/build
 PWD := $(shell pwd)
 all:
-	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) modules
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
 
 clean: 
-	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) clean
+	$(MAKE) -C $(KDIR) M=$(PWD) clean


### PR DESCRIPTION
This change makes it possible to build on kernels 5.4 or higher. It should be backward compatible all the way back to kernel 2.6.

If support for 2.6 and lower is required, we'd have to check for kernel version in the Makefile and use `SUBDIRS=` or `M=` depending on version.