### PR TITLE
Include <linux/gpio/driver.h> for kernel versions >= 6.2

### DIFF
--- a/gpio-nct5104d.c
+++ b/gpio-nct5104d.c
@@ -15,6 +15,9 @@
 #include <linux/io.h>
 #include <linux/gpio.h>
 #include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
+#include <linux/gpio/driver.h>
+#endif
 
 #define DRVNAME "gpio-nct5104d"
 


### PR DESCRIPTION
It seems that <linux/gpio/driver.h> needs to be included for kerbel versions > 6.2. Otherwise it does not compile, at least that is what I found when using the module on Alpine Linux 3.19.